### PR TITLE
IDEA 2017.2 compatibility

### DIFF
--- a/src/com/othoslabs/InspectionToggler.java
+++ b/src/com/othoslabs/InspectionToggler.java
@@ -24,10 +24,7 @@ public class InspectionToggler {
             return;
 
         modifyAndCommitProjectProfile(modifiableModel -> {
-            if (isInspectionEnabled(toolId, file))
-                modifiableModel.disableTool(toolId, project);
-            else
-                modifiableModel.enableTool(toolId, project);
+            modifiableModel.setToolEnabled(toolId, !isInspectionEnabled(toolId, file));
         }, project);
 
         DaemonCodeAnalyzer.getInstance(project).restart();


### PR DESCRIPTION
I decided to break compatibility because your plugin is the only external usage (2017.2 next eap+).